### PR TITLE
Add support for toggleterm

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ require('jaq-nvim').setup{
 			size     = 10
 		},
 
+		toggleterm = {
+			-- Position of terminal, one of "vertical" | "horizontal" | "window" | "float"
+			position = "horizontal",
+
+			-- Size of terminal
+			size     = 10
+		},
+
 		quickfix = {
 			-- Position of quickfix window
 			position = "bot",
@@ -122,6 +130,7 @@ require('jaq-nvim').setup{
 - `float` • opens a floating window with `:lua vim.api.nvim_open_win()`
 - `quickfix` / `qf` • command output is placed in a quickfix
 - `term` • opens a terminal with `:terminal`
+- `toggleterm` • opens a terminal using :TermExec from [akinsho/toggleterm.nvim](https://github.com/akinsho/toggleterm.nvim)
 - `bang` • opens a small window with `:!`
 - `internal` • runs a vim command
 

--- a/lua/jaq-nvim.lua
+++ b/lua/jaq-nvim.lua
@@ -21,6 +21,10 @@ local config = {
 			position = "bot",
 			size     = 10
 		},
+		toggleterm = {
+			position = "horizontal",
+			size     = 10
+		},
 		quickfix = {
 			position = "bot",
 			size = 10
@@ -72,6 +76,10 @@ local function run(type)
 			local buf = vim.cmd(config.ui.terminal.position .. " " .. config.ui.terminal.size .. "new | term " .. cmd)
 			vim.api.nvim_buf_set_keymap(buf, 'n', '<ESC>', '<C-\\><C-n>:bdelete!<CR>', { silent = true })
 			vim.api.nvim_buf_set_option(buf, 'filetype', 'Jaq')
+			if config.ui.startinsert then vim.cmd("startinsert") end
+			if config.ui.wincmd then vim.cmd("wincmd p") end
+		elseif type == "toggleterm" then
+			vim.cmd('TermExec cmd="' .. cmd .. '" size=' .. config.ui.toggleterm.size .. " direction=" .. config.ui.toggleterm.position)
 			if config.ui.startinsert then vim.cmd("startinsert") end
 			if config.ui.wincmd then vim.cmd("wincmd p") end
 		end

--- a/plugin/jaq-nvim.lua
+++ b/plugin/jaq-nvim.lua
@@ -1,6 +1,6 @@
 vim.cmd [[
 	function! JaqCompletion(lead, cmd, cursor)
-		let valid_args = ['terminal', 'quickfix', 'qf', 'internal', 'bang', 'float']
+		let valid_args = ['terminal', 'quickfix', 'qf', 'internal', 'bang', 'float', 'toggleterm']
 		let l = len(a:lead) - 1
 		if l >= 0
 			let filtered_args = copy(valid_args)


### PR DESCRIPTION
Adds support for [akinsho/toggleterm.nvim](https://github.com/akinsho/toggleterm.nvim), using the :TermExec command. :TermExec supports the terminal position, but uses it's own internal config ("horizontal", "vertical", etc.) for it, so using config.ui.terminal would not work.

Also, this brings it to exactly 100 lines. 😆 (A few more lines could be saved by crunching down the if/else in M.Jaq() though!)