### PR TITLE
Fixed default configuration (added a comma)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ require('jaq-nvim').setup{
 	-- Commands used with 'Jaq'
 	cmds = {
 		-- Default UI used (see `Usage` for options)
-		default = "float"
+		default = "float",
 
 		-- Uses external commands such as 'g++' and 'cargo'
 		external = {


### PR DESCRIPTION
The default configuration shown in the README was broken because there was a comma missing.