### PR TITLE
Fix default configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ require('jaq-nvim').setup{
       position = "bot",
 
       -- Window size
-      size     = 10
+      size     = 10,
 
       -- Disable line numbers
       line_no  = false,


### PR DESCRIPTION
The default configuration in README was a comma missing.