### PR TITLE
feat: make `:Jaq<CR>` work for internal cmds

### DIFF
--- a/lua/jaq-nvim.lua
+++ b/lua/jaq-nvim.lua
@@ -233,7 +233,18 @@ end
 
 function M.Jaq(type)
   local file = io.open(vim.fn.expand('%:p:h') .. "/.jaq.json", "r")
-  type = type or config.behavior.default
+
+  -- Check if the filetype is in config.cmds.internal
+  if vim.tbl_contains(vim.tbl_keys(config.cmds.internal), vim.bo.filetype) then
+    -- Exit if the type was passed and isn't "internal"
+    if type and type ~= "internal" then
+      vim.cmd("echohl ErrorMsg | echo 'Error: Invalid type for internal command' | echohl None")
+      return
+    end
+    type = "internal"
+  else
+    type = type or config.behavior.default
+  end
 
   if file then
     project(type, file)


### PR DESCRIPTION
Now `:Jaq` works for internal commands without having to use `:Jaq internal`. If `:Jaq` gets passed any type other than "internal" for a filetype defined in `config.cmds.internal` table, it will exit with error.