### PR TITLE
feat: do system command if there is additional args(command)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ You can put any of the following in `require('jaq-nvim').setup()` or `.jaq.json`
 - `$fileBase`      • Basename of File (no extension)
 - `$moduleName`    • Python Module Name
 
+you can run any system command in any context (regardless current filetype),   
+`:Jaq {type} {sys ...args}`, execute system command and print with type.  
+ex. (Jaq float ls -al) will do `ls -al` and show in passed type.
+
+
+
 <div align="center" id="madewithlua">
 
 [![Lua](https://img.shields.io/badge/Made%20with%20Lua-blue.svg?style=for-the-badge&logo=lua)](#madewithlua)

--- a/lua/jaq-nvim.lua
+++ b/lua/jaq-nvim.lua
@@ -177,7 +177,7 @@ local function internal(cmd)
   vim.cmd(cmd)
 end
 
-local function run(type, cmd)
+local function run(type, cmd, ...)
   cmd = cmd or config.cmds.external[vim.bo.filetype]
 
   if not cmd then
@@ -189,7 +189,13 @@ local function run(type, cmd)
     vim.cmd("silent write")
   end
 
+  local args = ""
+  for _, v in ipairs({ ... }) do
+    args = args .. " " .. v
+  end
+
   cmd = substitute(cmd)
+  cmd = cmd .. args
   if type == "float" then
     float(cmd)
     return
@@ -231,8 +237,15 @@ local function project(type, file)
   run(type, cmd)
 end
 
-function M.Jaq(type)
+function M.Jaq(type, ...)
   local file = io.open(vim.fn.expand('%:p:h') .. "/.jaq.json", "r")
+
+  -- if there is additional arguments, then first run system exec
+  local cnt = select("#", ...)
+  if cnt > 0 then
+    run(type, ...)
+    return
+  end
 
   -- Check if the filetype is in config.cmds.internal
   if vim.tbl_contains(vim.tbl_keys(config.cmds.internal), vim.bo.filetype) then

--- a/plugin/jaq-nvim.lua
+++ b/plugin/jaq-nvim.lua
@@ -9,8 +9,8 @@ vim.cmd [[
 				return filtered_args
 			endif
 		endif
-		return valid_args
+		return valid_args . cmd
 	endfunction
 
-	command! -nargs=? -complete=customlist,JaqCompletion Jaq :lua require('jaq-nvim').Jaq(<f-args>)
+	command! -nargs=* -complete=customlist,JaqCompletion Jaq :lua require('jaq-nvim').Jaq(<f-args>)
 ]]


### PR DESCRIPTION
add functionality to doing external command when there is additional argument.

for example, if you run 
`:Jaq float ls -al`

then doing `ls -al` command in any context, and showing as passed type, in this case, `float`.

with this, you can run any command in any context with jaq.