### PR TITLE
General Improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -26,19 +26,13 @@
 ```lua
 require('jaq-nvim').setup{
   cmds = {
-    -- Uses vim commands
-    internal = {
-      lua = "luafile %",
-      vim = "source %"
-    },
-
-    -- Uses shell commands
-    external = {
-      markdown = "glow %",
-      python   = "python3 %",
-      go       = "go run %",
-      sh       = "sh %"
-    }
+    -- Prefix with a ':' to use a vim command
+    lua = ":luafile %",
+    vim = ":source %"
+    markdown = "glow %",
+    python = "python3 %",
+    go = "go run %",
+    sh = "sh %"
   },
 
   behavior = {
@@ -97,19 +91,15 @@ require('jaq-nvim').setup{
 ```
 
 ## Example JSON Config:
+
 ```json
 {
-  "internal": {
-    "lua": "luafile %",
-    "vim": "source %"
-  },
-
-  "external": {
-    "markdown": "glow %",
-    "python": "python3 %",
-    "go": "go run %",
-    "sh": "sh %"
-  }
+  "lua": ":luafile %",
+  "vim": ":source %",
+  "markdown": "glow %",
+  "python": "python3 %",
+  "go": "go run %",
+  "sh": "sh %"
 }
 ```
 

--- a/lua/jaq-nvim.lua
+++ b/lua/jaq-nvim.lua
@@ -15,14 +15,14 @@ local config = {
 
   ui = {
     float = {
-      border    = "none",
-      winhl     = "Normal",
-      borderhl  = "FloatBorder",
-      height    = 0.8,
-      width     = 0.8,
-      x         = 0.5,
-      y         = 0.5,
-      winblend  = 0
+      border   = "none",
+      winhl    = "Normal",
+      borderhl = "FloatBorder",
+      height   = 0.8,
+      width    = 0.8,
+      x        = 0.5,
+      y        = 0.5,
+      winblend = 0
     },
 
     terminal = {
@@ -96,7 +96,8 @@ local function float(cmd)
   vim.api.nvim_win_set_option(M.win, "winblend", config.ui.float.winblend)
 
   vim.api.nvim_buf_set_option(M.buf, "filetype", "Jaq")
-  vim.api.nvim_buf_set_keymap(M.buf, 'n', '<ESC>', '<cmd>:lua vim.api.nvim_win_close(' .. M.win .. ', true)<CR>', { silent = true })
+  vim.api.nvim_buf_set_keymap(M.buf, 'n', '<ESC>', '<cmd>:lua vim.api.nvim_win_close(' .. M.win .. ', true)<CR>',
+    { silent = true })
 
   vim.fn.termopen(cmd)
 

--- a/lua/jaq-nvim.lua
+++ b/lua/jaq-nvim.lua
@@ -165,8 +165,7 @@ local function internal(cmd)
   cmd = cmd or config.cmds.internal[vim.bo.filetype]
 
   if not cmd then
-    vim.cmd("echohl ErrorMsg | echo 'Error: Invalid command' | echohl None")
-    return
+    error("Jaq-nvim: Invalid command")
   end
 
   if config.behavior.autosave then
@@ -181,8 +180,7 @@ local function run(type, cmd)
   cmd = cmd or config.cmds.external[vim.bo.filetype]
 
   if not cmd then
-    vim.cmd("echohl ErrorMsg | echo 'Error: Invalid command' | echohl None")
-    return
+    error("Jaq-nvim: Invalid command")
   end
 
   if config.behavior.autosave then
@@ -204,7 +202,7 @@ local function run(type, cmd)
     return
   end
 
-  vim.cmd("echohl ErrorMsg | echo 'Error: Invalid type' | echohl None")
+  error("Jaq-nvim: Invalid type")
 end
 
 local function project(type, file)
@@ -213,7 +211,7 @@ local function project(type, file)
   io.close(file)
 
   if not status then
-    vim.cmd("echohl ErrorMsg | echo 'Error: Invalid json' | echohl None")
+    error("Jaq-nvim: Invalid json")
     return
   end
 
@@ -238,8 +236,7 @@ function M.Jaq(type)
   if vim.tbl_contains(vim.tbl_keys(config.cmds.internal), vim.bo.filetype) then
     -- Exit if the type was passed and isn't "internal"
     if type and type ~= "internal" then
-      vim.cmd("echohl ErrorMsg | echo 'Error: Invalid type for internal command' | echohl None")
-      return
+      error("Jaq-nvim: Invalid type for internal command")
     end
     type = "internal"
   else

--- a/lua/jaq-nvim.lua
+++ b/lua/jaq-nvim.lua
@@ -127,7 +127,8 @@ local function term(cmd)
   end
 
   if not config.ui.terminal.line_no then
-    vim.cmd("setlocal nonumber | setlocal norelativenumber")
+    vim.opt_local.number = false
+    vim.opt_local.relativenumber = false
   end
 
   if config.behavior.wincmd then

--- a/lua/jaq-nvim.lua
+++ b/lua/jaq-nvim.lua
@@ -112,7 +112,9 @@ local function float(cmd)
 end
 
 local function term(cmd)
-  vim.cmd(config.ui.terminal.position .. " " .. config.ui.terminal.size .. "new | term " .. cmd)
+  vim.cmd(config.ui.terminal.position .. " " .. config.ui.terminal.size .. "new")
+
+  vim.fn.termopen(cmd)
 
   M.buf = vim.api.nvim_get_current_buf()
 


### PR DESCRIPTION
This PR adds:
* `editorcofig`: Since is natively supported since neovim 0.9,
* uses Lua's default error function for handling errors
* Add's new way to detect if a command is internal or not (deprecates old configuration)
  * Removes a lot of logic
  * More straightforward configuration
* Use `termopen()` when possible instead of `| term`
* Fix some control flows