### PR TITLE
feat(option): add option to close existing Jaq buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,19 @@ require('jaq-nvim').setup{
 
   behavior = {
     -- Default type
-    default     = "float",
+    default       = "float",
 
     -- Start in insert mode
-    startinsert = false,
+    startinsert   = false,
 
     -- Use `wincmd p` on startup
-    wincmd      = false,
+    wincmd        = false,
 
     -- Auto-save files
-    autosave    = false
+    autosave      = false,
+
+    -- Close existing Jaq buffers
+    closeexisting = false
   },
 
   ui = {

--- a/lua/jaq-nvim.lua
+++ b/lua/jaq-nvim.lua
@@ -7,10 +7,11 @@ local config = {
   },
 
   behavior = {
-    default     = "float",
-    startinsert = false,
-    wincmd      = false,
-    autosave    = false
+    default       = "float",
+    startinsert   = false,
+    wincmd        = false,
+    autosave      = false,
+    closeexisting = false
   },
 
   ui = {
@@ -112,6 +113,15 @@ local function float(cmd)
 end
 
 local function term(cmd)
+  if config.behavior.closeexisting then
+    for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+      local filetype = vim.api.nvim_buf_get_option(bufnr, "filetype")
+      if filetype == "Jaq" then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end
+  end
+
   vim.cmd(config.ui.terminal.position .. " " .. config.ui.terminal.size .. "new | term " .. cmd)
 
   M.buf = vim.api.nvim_get_current_buf()


### PR DESCRIPTION
Hi, in this PR I added an option to close existing Jaq buffers upon starting a new quickrun.

I like having a `terminal` quickrun buffer side-by-side with my source code buffer, and leave that open as I make modifications to the source code and rerun (see image at the bottom). However, every time I run `:Jaq` it opens a new quickrun buffer. By adding this option, it becomes possible to automatically close the buffer before running a new quickrun.

It seems that `nvim_buf_get_option` has been [deprecated](https://neovim.io/doc/user/deprecated.html#deprecated-0.10) in 0.10, but I'm deliberately using it in order to make it consistent with the other uses of `nvim_buf_{set,get}_option`.

```
-- Note: Irrelevant options are omitted
require("jaq-nvim").setup({
  behavior = {
    default = "terminal",
    -- New option added in this PR
    -- closeexisting = true,
  },

  ui = {
    terminal = {
      position = "vert",
      size = 80,
      line_no = false
    },
  }
})
```

How I normally use jaq: show the results side-by-side, and edit, run, and repeat
![image](https://github.com/user-attachments/assets/37659c08-29ea-4466-8f99-0c0d5d2d88fd)
